### PR TITLE
impl Display and Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 default = ["encode", "decode"]
 encode = []
 decode = []
+error = []
 
 [badges]
 travis-ci = { repository = "naim94a/binascii-rs", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 default = ["encode", "decode"]
 encode = []
 decode = []
-error = []
+std = []
 
 [badges]
 travis-ci = { repository = "naim94a/binascii-rs", branch = "master" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "error"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 
 //! This crate contains encoders & decoders for various formats (base16, base32 & base64)
@@ -44,7 +44,7 @@ impl core::fmt::Display for ConvertError {
     }
 }
 
-#[cfg(feature = "error")]
+#[cfg(feature = "std")]
 impl std::error::Error for ConvertError {}
 
 /// **Base16 Decoder** - Converts a hexadecimal string to it's binary form.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,17 @@ pub enum ConvertError {
     InvalidInput,
 }
 
+impl core::fmt::Display for ConvertError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use ConvertError::*;
+        match self {
+            InvalidInputLength => write!(f, "Input buffer length too short or incorrect padding."),
+            InvalidOutputLength => write!(f, "Output buffer too short."),
+            InvalidInput => write!(f, "Failure to decode due to malformed input."),
+        }
+    }
+}
+
 /// **Base16 Decoder** - Converts a hexadecimal string to it's binary form.
 ///
 /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "error"), no_std)]
 #![forbid(unsafe_code)]
 
 //! This crate contains encoders & decoders for various formats (base16, base32 & base64)
@@ -43,6 +43,9 @@ impl core::fmt::Display for ConvertError {
         }
     }
 }
+
+#[cfg(feature = "error")]
+impl std::error::Error for ConvertError {}
 
 /// **Base16 Decoder** - Converts a hexadecimal string to it's binary form.
 ///


### PR DESCRIPTION
`core::fmt::Display` on error types is very handy when using error handling crates such as `anyhow`. The first commit in this PR would allow code like the following to be written:

```rust
use anyhow::{Error, Result};
use binascii::hex2bin;

fn main() -> Result<()> {
    let mut buf = [0u8; 4];
    hex2bin(b"deadbeef", &mut buf).map_err(Error::msg)?;
    Ok(())
}
```

The second commit furthermore implements `std::error::Error` behind a feature flag "error", while maintaining `#![no_std]` if the feature is not selected (and it's off by default). This allows the following code, which is even better:

```rust
use anyhow::Result;
use binascii::hex2bin;

fn main() -> Result<()> {
    let mut buf = [0u8; 4];
    hex2bin(b"deadbeef", &mut buf)?;
    Ok(())
}
```

Thanks for considering this PR. I'd be happy to take feedback if you have suggestions!